### PR TITLE
CI for examples + native EOF

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,43 @@
+name: examples
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [main]
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  check:
+    strategy:
+      fail-fast: true
+
+    name: Foundry project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Run Forge build
+        id: build
+        run: forge build
+
+      - name: Rust BLS multisig example
+        run: cargo run --manifest-path  ./examples/bls-multisig/rust/Cargo.toml
+      
+      - name: Python BLS multisig example
+        run: | 
+            pip install web3 py_ecc
+            python ./examples/bls-multisig/python/multisig.py

--- a/README.md
+++ b/README.md
@@ -5,16 +5,9 @@ Set of solidity utilities to ease deployment and usage of applications on
 
 ## EOF support
 
-This repository is configured to compile contracts for [EOF]. This is done by using solc binary from [forge-eof] repository distrbuted as a docker image. To be able to compile contracts you will need to have [Docker] installed.
+Forge has built-in support for [EOF]. This is done by using solc binary from [forge-eof] repository distrbuted as a docker image. To be able to compile contracts you will need to have [Docker] installed. Once it's installed, and forge version is up to date (run `foundryup` if needed), you can add `--eof` flag to any forge command to try out EOF compilation.
 
-To make sure that everything is working properly you can run the following command:
-```shell
-$ ./eof-solc --version
-```
-
-It will pull the docker image on a first run and should print the version of the solc binary.
-
-After that, make sure that your forge version is up to data (run `foundryup` if needed), and then you should be able to use all usual forge commands —— all contracts will get compiled for EOF.
+This repository is configured to compile contracts for [EOF] by default by setting `eof = true` in the `foundry.toml` file.
 
 ## EIP-7702 support
 

--- a/eof-solc
+++ b/eof-solc
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker run --rm -i -v "$(pwd):/app/root" ghcr.io/paradigmxyz/forge-eof:latest "$@"

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,9 +3,5 @@ src = "src"
 out = "out"
 libs = ["lib"]
 
-# settings required for EOF
-via_ir = true
-evm_version = "prague"
-eof_version = 1
-solc = "./eof-solc"
+eof = true
 alphanet = true


### PR DESCRIPTION
Adds CI for Rust/Python BLS examples as discussed in https://github.com/paradigmxyz/forge-alphanet/pull/9#issuecomment-2388745962

Adds usage of `--eof` flag, removing `eof-solc` helper